### PR TITLE
Don't die if a repo has no versions.gz

### DIFF
--- a/rapid/rapid.py
+++ b/rapid/rapid.py
@@ -358,8 +358,11 @@ class Repository(object):
 				packages[name].dependencies == deps and tag):
 				packages[name].tags.add(tag)
 
-		with closing(gzip.open(self.versions_gz)) as f:
-			map(read_line, f)
+		try:
+			with closing(gzip.open(self.versions_gz)) as f:
+				map(read_line, f)
+		except IOError:
+			pass # No versions in this repo.
 
 		return packages
 


### PR DESCRIPTION
pr-downloader stores repos.gz in `~/.spring/rapid/repos.springrts.com/repos.gz` and rapid tries to access `~/.spring/rapid/repos.springrts.com/versions.gz` which doesn't exist. The change makes rapid treat reos.springrts.com as an offline repo with no packages. This is useful because it allows rapid to coexist with pr-downloader.

I need it because I want to try using rapid to download mods in weblobby while still using pr-downloader for maps and engines, after @ForbodingAngel's praise toward rapid finally convinced me.
